### PR TITLE
Tweaked the face_select color of ThemeView3D

### DIFF
--- a/blender_pro.xml
+++ b/blender_pro.xml
@@ -373,7 +373,7 @@
         edge_facesel="#6b6b6b"
         freestyle_edge_mark="#0162a7"
         face="#3535354d"
-        face_select="#ffffff6d"
+        face_select="#1897cf5b"
         face_dot="#ffffff"
         facedot_size="5"
         freestyle_face_mark="#013f6bff"


### PR DESCRIPTION
Made the face_select of ThemeView3D same color as the face_select of ThemeImageEditor for better readability (and looks) on bright matcaps. This also removes the ambiguity between Image Editor and 3D Viewport selection colors.

Before:
![image](https://github.com/paulcoops/blender_pro-theme/assets/21021662/ffd6061a-cb7e-436d-a5da-09d63d2ea23a)


After:
![image](https://github.com/paulcoops/blender_pro-theme/assets/21021662/535daccc-bebb-41ba-8310-f80fd7ea36be)